### PR TITLE
abort project upload for zero size gpkg

### DIFF
--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -65,6 +65,8 @@ from .utils import (
     is_valid_uuid,
     gpkg_wkb_to_wkt,
     format_time_delta,
+    is_versioned_file,
+    is_valid_gpkg,
 )
 from .utils import (
     is_name_allowed,
@@ -768,6 +770,10 @@ def project_push(namespace, project_name):
     blacklisted_files = []
     for change in changes.values():
         for f in change:
+            # check if .gpkg file is valid
+            if is_versioned_file(f["path"]):
+                if not is_valid_gpkg(f):
+                    abort(400, "File {} is not valid".format(f["path"]))
             if is_file_name_blacklisted(f["path"], current_app.config["BLACKLIST"]):
                 blacklisted_files.append(f)
             # all file need to be unique after sanitized
@@ -992,6 +998,10 @@ def push_finish(transaction_id):
                 % (f["path"], project_path),
                 exc_info=True,
             )
+            # check if .gpkg file is valid
+            if is_versioned_file(dest_file):
+                if not is_valid_gpkg(f):
+                    corrupted_files.append(f["path"])
             corrupted_files.append(f["path"])
 
     if corrupted_files:

--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -400,6 +400,7 @@ def get_order_param(cls: Model, order_param: OrderParam) -> Optional[UnaryExpres
     elif order_param.direction == "desc":
         return order_attr.desc()
 
+
 def is_valid_gpkg(file_meta):
-    """ Check if diff file is valid"""
+    """Check if diff file is valid"""
     return file_meta["size"] != 0

--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -399,3 +399,7 @@ def get_order_param(cls: Model, order_param: OrderParam) -> Optional[UnaryExpres
         return order_attr.asc()
     elif order_param.direction == "desc":
         return order_attr.desc()
+
+def is_valid_gpkg(file_meta):
+    """ Check if diff file is valid"""
+    return file_meta["size"] != 0

--- a/server/mergin/tests/test_project_controller.py
+++ b/server/mergin/tests/test_project_controller.py
@@ -1004,11 +1004,13 @@ def _get_changes_with_diff(project_dir):
     changes["updated"].append(diff_meta)
     return changes
 
+
 def _get_changes_with_diff_0_size(project_dir):
     changes = _get_changes_with_diff(project_dir)
     # tweak file size
     changes["updated"][1]["size"] = 0
     return changes
+
 
 test_push_data = [
     (
@@ -1528,6 +1530,7 @@ def test_push_diff_finish(client):
     upload_chunks(upload_dir, upload.changes)
     resp = client.post("/v1/project/push/finish/{}".format(upload.id))
     assert resp.status_code == 422
+
 
 def test_push_no_diff_finish(client):
     working_dir = os.path.join(TMP_DIR, "test_push_no_diff_finish")


### PR DESCRIPTION
fixes: [mergin#938](https://gitlab.lutraconsulting.co.uk/mergin/mergin/-/issues/938) - empty .gpkg breaks the project

solution: abort project upload for zero size gpkg (check on upload start and finish when the file can be restored from chunks)