### PR TITLE
Fix workspace storage usage

### DIFF
--- a/LICENSES/CLA-signed-list.md
+++ b/LICENSES/CLA-signed-list.md
@@ -12,3 +12,4 @@ C/ My company has custom contribution contract with Lutra Consulting Ltd. or I a
 
 * PeterPetrik, 31st March 2023
 * tomasMizera, 31st March 2023
+* varmar05, 12th April 2023

--- a/server/mergin/sync/workspace.py
+++ b/server/mergin/sync/workspace.py
@@ -57,7 +57,7 @@ class GlobalWorkspace(AbstractWorkspace):
         # get only what is necessary from db to calculate final usage
         from .models import Project
 
-        projects_usage_list = db.session.query(Project.disk_usage).all()
+        projects_usage_list = db.session.query(Project.disk_usage).filter(Project.removed_at.is_(None)).all()
         return sum(p.disk_usage for p in projects_usage_list)
 
     def user_has_permissions(self, user, permissions):


### PR DESCRIPTION
Projects marked for removal should not be counted into workspace storage limit.