### PR TITLE
custom field class that filters whitespaces

### DIFF
--- a/server/mergin/app.py
+++ b/server/mergin/app.py
@@ -18,6 +18,7 @@ from flask_migrate import Migrate
 from flask_mail import Mail
 from connexion.apps.flask_app import FlaskJSONEncoder
 from flask_wtf import FlaskForm
+from wtforms import StringField
 from pathlib import Path
 import sys
 import time
@@ -433,3 +434,14 @@ class ResponseError:
 
     def to_dict(self) -> Dict:
         return dict(code=self.code, detail=self.detail + f" ({self.code})")
+
+def whitespace_filter(obj):
+    return obj.strip() if isinstance(obj, str) else obj
+
+class CustomStringField(StringField):
+    """ Custom class for string form fields """
+    def __init__(self, *args, **kwargs):
+        filters = kwargs.get("filters")
+        # add whitespace filter
+        kwargs["filters"] = (*filters, whitespace_filter) if filters else (whitespace_filter, )
+        super().__init__(*args, **kwargs)

--- a/server/mergin/auth/forms.py
+++ b/server/mergin/auth/forms.py
@@ -56,7 +56,7 @@ class RegisterUserForm(FlaskForm):
         "Username",
         validators=[validators.Length(min=4, max=25), username_validation],
     )
-    email = StringField(
+    email = CustomStringField(
         "Email Address",
         validators=[DataRequired(), Email()],
     )

--- a/server/mergin/auth/forms.py
+++ b/server/mergin/auth/forms.py
@@ -16,11 +16,7 @@ from wtforms.validators import (
 )
 
 from .models import User
-from ..app import UpdateForm
-
-
-def whitespace_filter(obj):
-    return obj.strip() if isinstance(obj, str) else obj
+from ..app import UpdateForm, CustomStringField
 
 
 def username_validation(form, field):
@@ -51,20 +47,18 @@ class PasswordValidator:
 class LoginForm(FlaskForm):
     """Form with username and password fields for user to sign in."""
 
-    login = StringField(validators=[DataRequired(), Length(max=80)])
+    login = CustomStringField(validators=[DataRequired(), Length(max=80)])
     password = PasswordField(validators=[DataRequired()])
 
 
 class RegisterUserForm(FlaskForm):
-    username = StringField(
+    username = CustomStringField(
         "Username",
         validators=[validators.Length(min=4, max=25), username_validation],
-        filters=(whitespace_filter,),
     )
     email = StringField(
         "Email Address",
         validators=[DataRequired(), Email()],
-        filters=(whitespace_filter,),
     )
 
     def validate(self):
@@ -85,8 +79,8 @@ class RegisterUserForm(FlaskForm):
 
 
 class ResetPasswordForm(FlaskForm):
-    email = StringField(
-        "Email Address", [DataRequired(), Email()], filters=(whitespace_filter,)
+    email = CustomStringField(
+        "Email Address", [DataRequired(), Email()],
     )
 
 
@@ -119,9 +113,9 @@ class UserProfileDataForm(UpdateForm):
     """This form is for user profile update"""
 
     receive_notifications = BooleanField("Receive notifications", [Optional()])
-    first_name = StringField("First Name", [Optional()], filters=(whitespace_filter,))
-    last_name = StringField("Last Name", [Optional()], filters=(whitespace_filter,))
-    email = StringField("Email", [Optional(), Email()], filters=(whitespace_filter,))
+    first_name = CustomStringField("First Name", [Optional()])
+    last_name = CustomStringField("Last Name", [Optional()])
+    email = CustomStringField("Email", [Optional(), Email()])
 
 
 class ApiLoginForm(LoginForm):

--- a/server/mergin/tests/test_auth.py
+++ b/server/mergin/tests/test_auth.py
@@ -24,9 +24,10 @@ def client(app):
     return client
 
 
-# login tests: success, success with email login, invalid password, missing password, wrong headers
+# login tests: success, success with trailing space, success with email login, invalid password, missing password, wrong headers
 test_login_data = [
     ({"login": "mergin", "password": "ilovemergin"}, json_headers, 200),
+    ({"login": "mergin  ", "password": "ilovemergin"}, json_headers, 200),
     ({"login": "mergin@mergin.com", "password": "ilovemergin"}, json_headers, 200),
     ({"login": "mergin", "password": "ilovemergi"}, json_headers, 401),
     ({"login": "mergin"}, json_headers, 401),


### PR DESCRIPTION
CU: https://app.clickup.com/t/862jv6teu

GL: https://gitlab.lutraconsulting.co.uk/mergin/mergin/-/merge_requests/812 - apply in workspace create form

rename usernames: https://gitlab.lutraconsulting.co.uk/lutraconsulting/operations/-/merge_requests/5

Change:

when logging in, server removes trailing spaces from username (autocomplete on mobiles added invisible space which lead to login failures)

Custom class for text fields was created and used at any place we want to remove leading and trailing spaces

In following user inputs there is already check for trailing spaces and they do not use forms:
- create workspace invitation
- add project
- clone project