### PR TITLE
Add sort in json fields

### DIFF
--- a/server/mergin/sync/private_api_controller.py
+++ b/server/mergin/sync/private_api_controller.py
@@ -182,7 +182,9 @@ def list_projects(
             if not order_param:
                 continue
             if order_param.name == "workspace":
-                order_by_params.append(text(f"workspace_name {order_param.direction}"))
+                order_by_params.append(
+                    text(f"workspace_name {order_param.direction.value}")
+                )
             else:
                 order_by_params.append(get_order_param(Project, order_param))
         projects = projects.order_by(*order_by_params)

--- a/server/mergin/sync/private_api_controller.py
+++ b/server/mergin/sync/private_api_controller.py
@@ -21,9 +21,8 @@ from .permissions import (
     ProjectPermissions,
     check_workspace_permissions,
 )
-from .utils import get_project_path, split_order_param, get_order_param
-
-from ..utils import parse_order_params
+from .utils import get_project_path
+from ..utils import parse_order_params, split_order_param, get_order_param
 
 project_access_granted = signal("project_access_granted")
 

--- a/server/mergin/sync/utils.py
+++ b/server/mergin/sync/utils.py
@@ -7,19 +7,13 @@ import os
 import hashlib
 import re
 import secrets
-from collections import namedtuple
 from threading import Timer
-from typing import Optional
 from uuid import UUID
 from datetime import timedelta
-
-from flask_sqlalchemy import Model
 from pathvalidate import sanitize_filename
 from shapely import wkb
 from shapely.errors import WKBReadingError
 from gevent import sleep
-from sqlalchemy import Column
-from sqlalchemy.sql.elements import UnaryExpression
 
 
 def generate_checksum(file, chunk_size=4096):
@@ -375,30 +369,6 @@ def format_time_delta(delta: timedelta) -> str:
         else:
             difference = "N/A"
     return difference
-
-
-OrderParam = namedtuple("OrderParam", "name direction")
-
-
-def split_order_param(order_param: str) -> Optional[OrderParam]:
-    """Split db query order parameter"""
-    try:
-        col, order = order_param.strip().split(" ")
-    except ValueError:
-        return
-    if order.lower() in ["asc", "desc"]:
-        return OrderParam(col, order.lower())
-
-
-def get_order_param(cls: Model, order_param: OrderParam) -> Optional[UnaryExpression]:
-    """Return order by clause parameter for SQL query"""
-    order_attr = cls.__table__.c.get(order_param.name, None)
-    if not isinstance(order_attr, Column):
-        return
-    if order_param.direction == "asc":
-        return order_attr.asc()
-    elif order_param.direction == "desc":
-        return order_attr.desc()
 
 
 def is_valid_gpkg(file_meta):

--- a/server/mergin/utils.py
+++ b/server/mergin/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
 
 from collections import namedtuple
+from enum import Enum
 from flask_sqlalchemy import Model
 from sqlalchemy import Column, JSON
 from sqlalchemy.sql.elements import UnaryExpression
@@ -12,14 +13,19 @@ from typing import Optional
 OrderParam = namedtuple("OrderParam", "name direction")
 
 
+class OrderDirection(Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+
 def split_order_param(order_param: str) -> Optional[OrderParam]:
     """Split db query order parameter"""
     try:
         col, order = order_param.strip().split(" ")
+        direction = OrderDirection(order.lower())
     except ValueError:
         return
-    if order.lower() in ["asc", "desc"]:
-        return OrderParam(col, order.lower())
+    return OrderParam(col, direction)
 
 
 def get_order_param(
@@ -64,9 +70,9 @@ def get_order_param(
         else:
             order_attr = order_attr[attr].as_string()
 
-    if order_param.direction == "asc":
+    if order_param.direction is OrderDirection.ASC:
         return order_attr.asc()
-    elif order_param.direction == "desc":
+    elif order_param.direction is OrderDirection.DESC:
         return order_attr.desc()
 
 

--- a/server/mergin/utils.py
+++ b/server/mergin/utils.py
@@ -22,7 +22,9 @@ def split_order_param(order_param: str) -> Optional[OrderParam]:
         return OrderParam(col, order.lower())
 
 
-def get_order_param(cls: Model, order_param: OrderParam, json_sort: dict = None) -> Optional[UnaryExpression]:
+def get_order_param(
+    cls: Model, order_param: OrderParam, json_sort: dict = None
+) -> Optional[UnaryExpression]:
     """Return order by clause parameter for SQL query
 
     :param cls: Db model class

--- a/server/mergin/utils.py
+++ b/server/mergin/utils.py
@@ -1,56 +1,91 @@
 # Copyright (C) Lutra Consulting Limited
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-MerginMaps-Commercial
-from sqlalchemy import Column
+
+from collections import namedtuple
+from flask_sqlalchemy import Model
+from sqlalchemy import Column, JSON
+from sqlalchemy.sql.elements import UnaryExpression
+from typing import Optional
 
 
-def parse_order_params(cls, order_params, json_sort=None):
-    """Parse order parameters in query string
+OrderParam = namedtuple("OrderParam", "name direction")
+
+
+def split_order_param(order_param: str) -> Optional[OrderParam]:
+    """Split db query order parameter"""
+    try:
+        col, order = order_param.strip().split(" ")
+    except ValueError:
+        return
+    if order.lower() in ["asc", "desc"]:
+        return OrderParam(col, order.lower())
+
+
+def get_order_param(cls: Model, order_param: OrderParam, json_sort: dict = None) -> Optional[UnaryExpression]:
+    """Return order by clause parameter for SQL query
 
     :param cls: Db model class
     :type cls: db.Model
-    :param order_params: order parameter string, e.g. 'name ASC,created DESC,meta.storage ASC'
+    :param order_param: parsed order parameter
+    :type order_param: OrderParam
+    :param json_sort: type mapping for sort by json field, e.g. '{"storage": "int"}', defaults to None
+    :type json_sort: dict
+    """
+    # find candidate for nested json sort
+    if "." in order_param.name:
+        col, attr = order_param.name.split(".")
+    else:
+        col = order_param.name
+        attr = None
+    order_attr = cls.__table__.c.get(col, None)
+    if not isinstance(order_attr, Column):
+        return
+    # sort by key in JSON field
+    if attr:
+        if not json_sort:
+            return
+        # unknown field
+        if attr not in json_sort:
+            return
+        if not isinstance(order_attr.type, JSON):
+            return
+
+        # cast expected type for json key sort
+        # would result in something like "(json_column->>'attribute')::type"))
+        if json_sort[attr] == "int":
+            order_attr = order_attr[attr].as_numeric(20, 0)  # to handle bigint
+        elif json_sort[attr] == "float":
+            order_attr = order_attr[attr].as_float()
+        elif json_sort[attr] == "bool":
+            order_attr = order_attr[attr].as_boolean()
+        else:
+            order_attr = order_attr[attr].as_string()
+
+    if order_param.direction == "asc":
+        return order_attr.asc()
+    elif order_param.direction == "desc":
+        return order_attr.desc()
+
+
+def parse_order_params(cls: Model, order_params: str, json_sort: dict = None):
+    """Convert order parameters in query string to list of order by clauses.
+
+    :param cls: Db model class
+    :type cls: db.Model
+    :param order_params: order parameter query string, e.g. 'name ASC,created DESC,meta.storage ASC'
     :type order_params: str
+    :param json_sort: type mapping for sort by json field, e.g. '{"storage": "int"}', defaults to None
+    :type json_sort: dict
 
     :rtype: List[Column]
     """
     order_by_params = []
     for p in order_params.split(","):
-        try:
-            col, order = p.strip().split(" ")
-        except ValueError:
+        order_param = split_order_param(p)
+        if not order_param:
             continue
-        # find candidate for nested json sort
-        if "." in col:
-            col, attr = col.split(".")
-        else:
-            attr = None
-        order_attr = cls.__table__.c.get(col, None)
-        if not isinstance(order_attr, Column):
-            continue
-        # sort by key in JSON field
-        if attr:
-            # unknown field
-            if attr not in json_sort:
-                continue
-
-            from sqlalchemy import JSON
-            if not isinstance(order_attr.type, JSON):
-                continue
-
-            # cast expected type for json key sort
-            # would result in something like "(json_column->>'attribute')::type"))
-            if json_sort[attr] == "int":
-                order_attr = order_attr[attr].as_numeric(20, 0)  # to handle bigint
-            elif json_sort[attr] == "float":
-                order_attr = order_attr[attr].as_float()
-            elif json_sort[attr] == "bool":
-                order_attr = order_attr[attr].as_boolean()
-            else:
-                order_attr = order_attr[attr].as_string()
-
-        if order == "ASC":
-            order_by_params.append(order_attr.asc())
-        elif order == "DESC":
-            order_by_params.append(order_attr.desc())
+        order_attr = get_order_param(cls, order_param, json_sort)
+        if order_attr is not None:
+            order_by_params.append(order_attr)
     return order_by_params

--- a/server/mergin/utils.py
+++ b/server/mergin/utils.py
@@ -4,12 +4,12 @@
 from sqlalchemy import Column
 
 
-def parse_order_params(cls, order_params):
+def parse_order_params(cls, order_params, json_sort=None):
     """Parse order parameters in query string
 
     :param cls: Db model class
     :type cls: db.Model
-    :param order_params: order parameter string, e.g. 'name ASC,created DESC'
+    :param order_params: order parameter string, e.g. 'name ASC,created DESC,meta.storage ASC'
     :type order_params: str
 
     :rtype: List[Column]
@@ -20,9 +20,34 @@ def parse_order_params(cls, order_params):
             col, order = p.strip().split(" ")
         except ValueError:
             continue
+        # find candidate for nested json sort
+        if "." in col:
+            col, attr = col.split(".")
+        else:
+            attr = None
         order_attr = cls.__table__.c.get(col, None)
         if not isinstance(order_attr, Column):
             continue
+        # sort by key in JSON field
+        if attr:
+            # unknown field
+            if attr not in json_sort:
+                continue
+
+            from sqlalchemy import JSON
+            if not isinstance(order_attr.type, JSON):
+                continue
+
+            # cast expected type for json key sort
+            # would result in something like "(json_column->>'attribute')::type"))
+            if json_sort[attr] == "int":
+                order_attr = order_attr[attr].as_numeric(20, 0)  # to handle bigint
+            elif json_sort[attr] == "float":
+                order_attr = order_attr[attr].as_float()
+            elif json_sort[attr] == "bool":
+                order_attr = order_attr[attr].as_boolean()
+            else:
+                order_attr = order_attr[attr].as_string()
 
         if order == "ASC":
             order_by_params.append(order_attr.asc())


### PR DESCRIPTION
Add support to sort by keys in db JSON fields in query parameters as `json_field.key`, e.g. `?order_params=meta.storage ASC` 