### PR TITLE
Fix failing changeset details / file restore

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -149,6 +149,11 @@ class Project(db.Model):
             # ('v1', 'added', {'checksum': '89469a6482267de394c7c7270cb7ffafe694ea76', 'location': 'v1/data/tests.gpkg',
             # 'mtime': '2019-07-18T07:52:38.770113Z', 'path': 'base.gpkg', 'size': 98304})
 
+            # make sure we have "location" in response (e.g. 'added' changes do not have it stored)
+            # which consists of version and file path
+            if "location" not in r.value:
+                r.value["location"] = os.path.join(r.name, r.value["path"])
+
             history[r.name] = {**r.value, "change": r.change}
             # end of file history
             if r.change in ["added", "removed"]:

--- a/server/mergin/sync/public_api_controller.py
+++ b/server/mergin/sync/public_api_controller.py
@@ -1250,6 +1250,8 @@ def get_resource_changeset(project_name, namespace, version_id, path):  # noqa: 
     project.storage.flush_geodiff_logger()  # clean geodiff logger
 
     try:
+        if not os.path.exists(basefile):
+            version.project.storage.restore_versioned_file(path, version_id)
         if not os.path.exists(json_file):
             version.project.storage.geodiff.list_changes(changeset, json_file)
         if not os.path.exists(schema_file):

--- a/server/mergin/tests/fixtures.py
+++ b/server/mergin/tests/fixtures.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import uuid
+from copy import deepcopy
 from shutil import copy, move
 from flask import current_app
 from flask_login import current_user
@@ -165,8 +166,8 @@ def diff_project(app):
         for i, change in enumerate(changes):
             ver = "v{}".format(i + 2)
             if change["added"]:
-                meta = change["added"][0]
-                meta["location"] = os.path.join(ver, os.path.basename(meta["path"]))
+                meta = deepcopy(change["added"][0])  # during push we do not store 'location' in 'added' metadata
+                meta["location"] = os.path.join(ver, meta["path"])
                 new_file = os.path.join(project.storage.project_dir, meta["location"])
                 os.makedirs(os.path.dirname(new_file), exist_ok=True)
                 copy(os.path.join(test_project_dir, meta["path"]), new_file)

--- a/server/mergin/tests/fixtures.py
+++ b/server/mergin/tests/fixtures.py
@@ -166,7 +166,9 @@ def diff_project(app):
         for i, change in enumerate(changes):
             ver = "v{}".format(i + 2)
             if change["added"]:
-                meta = deepcopy(change["added"][0])  # during push we do not store 'location' in 'added' metadata
+                meta = deepcopy(
+                    change["added"][0]
+                )  # during push we do not store 'location' in 'added' metadata
                 meta["location"] = os.path.join(ver, meta["path"])
                 new_file = os.path.join(project.storage.project_dir, meta["location"])
                 os.makedirs(os.path.dirname(new_file), exist_ok=True)


### PR DESCRIPTION
Occasionally, during preview of file changeset details or downloading file at older version action failed with 'Missing base file' error. Two issues were identified:

- GET /v1/resource/changesets endpoint did not check for existence of basefile; 
 --> FIX: call gpkg restore function if basefile not present (e.g. for old version) 
- in case of gpkg file restoration from 'added' basefile it was found that metadata coming from db query did not contain 'location' key because we do not store it
--> FIX: missing key was added on the fly as it is computed property only cached in db, also test fixture was updated so it would match real scenario and won't hide failure 

 