### PR TITLE
Fix project download

### DIFF
--- a/server/mergin/sync/models.py
+++ b/server/mergin/sync/models.py
@@ -36,7 +36,7 @@ class Project(db.Model):
     )
     updated = db.Column(db.DateTime, onupdate=datetime.utcnow)
     # metadata for project files (see also FileInfoSchema)
-    files = db.Column(JSONB, default=[])
+    files = db.deferred(db.Column(JSONB, default=[]))
     tags = db.Column(ARRAY(String), server_default="{}")
     disk_usage = db.Column(BIGINT, nullable=False, default=0)
     latest_version = db.Column(db.String, index=True)


### PR DESCRIPTION
This PR mitigates risk of performance penalty for file download:
- do not load project.files from db if not needed
- in download endpoint use db query to fetch file location instead of filtering in app